### PR TITLE
add esp_netif requirement (IDFGH-8224)

### DIFF
--- a/ksz8863/CMakeLists.txt
+++ b/ksz8863/CMakeLists.txt
@@ -26,5 +26,5 @@ endif()
 
 idf_component_register(SRCS "${srcs}"
                        INCLUDE_DIRS ${include}
-                       REQUIRES "esp_event" # For using "ESP_EVENT_DECLARE_BASE" in header file
+		       REQUIRES "esp_event" "esp_netif" # For using "ESP_EVENT_DECLARE_BASE" in header file
                        PRIV_REQUIRES ${priv_requires})


### PR DESCRIPTION
Fix error: ~/esp-eth-drivers/ksz8863/include/esp_eth_netif_glue_ksz8863.h:8:10: fatal error: esp_netif.h: No such file or directory