### PR TITLE
force strip override_path from examples

### DIFF
--- a/ksz8863/idf_component.yml
+++ b/ksz8863/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.2"
+version: "0.2.3"
 targets:
   - esp32
 description: KSZ8863 Ethernet Driver


### PR DESCRIPTION
non-functional update to force strip override_path from examples in Component Registry