### PR TITLE
fix(lan867x): remove target specification from driver

### DIFF
--- a/ethernet_init/Kconfig.projbuild
+++ b/ethernet_init/Kconfig.projbuild
@@ -64,7 +64,10 @@ menu "Ethernet Configuration"
                     Goto https://www.microchip.com for more information about them.
 
             config ETHERNET_PHY_LAN867X
-                bool "LAN867x"
+                # bool "LAN867x"
+                # TODO: un-hide this option once processing of Matches and Rules is fixed in  IDF Component Manager and so LAN867x component can be conditionally included. 
+                bool
+                default n
                 help
                     The LAN8670/1/2 is a high-performance 10BASE-T1S single-pair Ethernet PHY transceiver for 10 Mbit/s half-duplex networking over a single pair of conductors
                     Goto https://www.microchip.com for more information about them.

--- a/ethernet_init/idf_component.yml
+++ b/ethernet_init/idf_component.yml
@@ -1,8 +1,6 @@
 dependencies:
   idf:
     version: '>=5.1'
-  lan867x:
-    version: '*'
 description: This component initializes Ethernet driver based on Espressif IoT Development Framework Configuration.
 url: https://github.com/espressif/esp-eth-drivers/tree/master/ethernet_init
-version: 0.2.0
+version: 0.2.1


### PR DESCRIPTION
Remove `target` specification from lan867x driver in order to not limit supported targets of dependents.