### PR TITLE
Add ESP32P4 support to RMII PHYs drivers and prevent warning from ethernet_init Kconfig.

### DIFF
--- a/adin1200/idf_component.yml
+++ b/adin1200/idf_component.yml
@@ -1,6 +1,7 @@
-version: "0.9.0"
+version: "0.9.1"
 targets:
   - esp32
+  - esp32p4
 description: ADIN1200 Ethernet PHY Driver
 url: https://github.com/espressif/esp-eth-drivers/tree/master/adin1200
 dependencies:

--- a/ethernet_init/Kconfig.projbuild
+++ b/ethernet_init/Kconfig.projbuild
@@ -63,14 +63,13 @@ menu "Ethernet Configuration"
                         KSZ8051, KSZ8061, KSZ8081, KSZ8091
                     Goto https://www.microchip.com for more information about them.
 
-            config ETHERNET_PHY_LAN867X
-                # bool "LAN867x"
-                # TODO: un-hide this option once processing of Matches and Rules is fixed in  IDF Component Manager and so LAN867x component can be conditionally included. 
-                bool
-                default n
-                help
-                    The LAN8670/1/2 is a high-performance 10BASE-T1S single-pair Ethernet PHY transceiver for 10 Mbit/s half-duplex networking over a single pair of conductors
-                    Goto https://www.microchip.com for more information about them.
+            # TODO: un-hide this option once processing of Matches and Rules is fixed in  IDF Component Manager and so LAN867x component can be conditionally included. 
+            #config ETHERNET_PHY_LAN867X
+            #    bool "LAN867x"
+            #    depends on !ETHERNET_INTERNAL_SUPPORT
+            #    help
+            #        The LAN8670/1/2 is a high-performance 10BASE-T1S single-pair Ethernet PHY transceiver for 10 Mbit/s half-duplex networking over a single pair of conductors
+            #        Goto https://www.microchip.com for more information about them.
         endchoice # ETHERNET_PHY_MODEL
 
         config ETHERNET_MDC_GPIO

--- a/ksz8863/idf_component.yml
+++ b/ksz8863/idf_component.yml
@@ -1,6 +1,7 @@
-version: "0.2.4"
+version: "0.2.5"
 targets:
   - esp32
+  - esp32p4
 description: KSZ8863 Ethernet Driver
 url: https://github.com/espressif/esp-eth-drivers/tree/master/ksz8863
 dependencies:

--- a/lan867x/idf_component.yml
+++ b/lan867x/idf_component.yml
@@ -1,6 +1,7 @@
-version: "0.9.0"
+version: "0.9.1"
 targets:
   - esp32
+  - esp32p4
 description: LAN867x Ethernet PHY Driver
 url: https://github.com/espressif/esp-eth-drivers/tree/master/lan867x
 dependencies:


### PR DESCRIPTION
Add ESP32-P4 as a supported target in PHYs which use RMII interface.
Change how lan867x option is disabled in `ethernet_init` so the warnings are not produced.