### PR TITLE
fix(ksz8863): replaced deprecated SMI GPIO configuration

### DIFF
--- a/eth_dummy_phy/README.md
+++ b/eth_dummy_phy/README.md
@@ -23,8 +23,14 @@ Note that usage of the `Dummy PHY` component does not conform with the RevMII st
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
     // Update vendor specific MAC config based on board configuration
     // No SMI, speed/duplex must be statically configured the same in both devices
+    // MIIM interface is not used since does not provide access to all registers
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    esp32_emac_config.smi_gpio.mdc_num = -1;
+    esp32_emac_config.smi_gpio.mdio_num = -1;
+#else
     esp32_emac_config.smi_mdc_gpio_num = -1;
     esp32_emac_config.smi_mdio_gpio_num = -1;
+#endif
 
     // Create new ESP32 Ethernet MAC instance
     esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);

--- a/ksz8863/examples/simple_switch/main/simple_switch_main.c
+++ b/ksz8863/examples/simple_switch/main/simple_switch_main.c
@@ -274,8 +274,9 @@ void app_main(void)
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
 
     phy_config.reset_gpio_num = -1; // KSZ8863 is reset by separate function call since multiple instances exist
-    esp32_emac_config.smi_mdc_gpio_num = -1; // MIIM interface is not used since does not provide access to all registers
-    esp32_emac_config.smi_mdio_gpio_num = -1;
+    // MIIM interface is not used since does not provide access to all registers
+    esp32_emac_config.smi_gpio.mdc_num = -1;
+    esp32_emac_config.smi_gpio.mdio_num = -1;
 
     // Init Host Ethernet Interface (Port 3)
     esp_eth_mac_t *host_mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);

--- a/ksz8863/examples/switch_mode/main/switch_main.c
+++ b/ksz8863/examples/switch_mode/main/switch_main.c
@@ -313,8 +313,9 @@ void app_main(void)
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
 
     phy_config.reset_gpio_num = -1; // KSZ8863 is reset by separate function call since multiple instances exist
-    esp32_emac_config.smi_mdc_gpio_num = -1; // MIIM interface is not used since does not provide access to all registers
-    esp32_emac_config.smi_mdio_gpio_num = -1;
+    // MIIM interface is not used since does not provide access to all registers
+    esp32_emac_config.smi_gpio.mdc_num = -1;
+    esp32_emac_config.smi_gpio.mdio_num = -1;
 
     // Init Host Ethernet Interface (Port 3)
     esp_eth_mac_t *host_mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);

--- a/ksz8863/examples/two_ports_mode/main/two_ports_main.c
+++ b/ksz8863/examples/two_ports_mode/main/two_ports_main.c
@@ -306,8 +306,9 @@ void app_main(void)
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
 
     phy_config.reset_gpio_num = -1; // KSZ8863 is reset by separate function call since multiple instances exist
-    esp32_emac_config.smi_mdc_gpio_num = -1; // MIIM interface is not used since does not provide access to all registers
-    esp32_emac_config.smi_mdio_gpio_num = -1;
+    // MIIM interface is not used since does not provide access to all registers
+    esp32_emac_config.smi_gpio.mdc_num = -1;
+    esp32_emac_config.smi_gpio.mdio_num = -1;
 
     // Init Host Ethernet Interface (Port 3)
     esp_eth_mac_t *host_mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);

--- a/ksz8863/idf_component.yml
+++ b/ksz8863/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.5"
+version: "0.2.6"
 targets:
   - esp32
   - esp32p4

--- a/ksz8863/src/esp_eth_pmac_ksz8863.c
+++ b/ksz8863/src/esp_eth_pmac_ksz8863.c
@@ -329,7 +329,7 @@ err:
     return ret;
 }
 
-static esp_err_t pmac_ksz8863_custom_ioctl(esp_eth_mac_t *mac, uint32_t cmd, void *data)
+static esp_err_t pmac_ksz8863_custom_ioctl(esp_eth_mac_t *mac, int cmd, void *data)
 {
     esp_err_t ret = ESP_OK;
     pmac_ksz8863_t *pmac = __containerof(mac, pmac_ksz8863_t, parent);

--- a/lan867x/idf_component.yml
+++ b/lan867x/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 targets:
   - esp32
   - esp32p4

--- a/lan867x/src/esp_eth_phy_lan867x.c
+++ b/lan867x/src/esp_eth_phy_lan867x.c
@@ -209,7 +209,7 @@ static esp_err_t lan867x_set_duplex(esp_eth_phy_t *phy, eth_duplex_t duplex)
     return ESP_ERR_NOT_SUPPORTED;
 }
 
-static esp_err_t lan867x_custom_ioctl(esp_eth_phy_t *phy, uint32_t cmd, void *data)
+static esp_err_t lan867x_custom_ioctl(esp_eth_phy_t *phy, int cmd, void *data)
 {
     esp_err_t ret;
     phy_802_3_t *phy_802_3 = esp_eth_phy_into_phy_802_3(phy);


### PR DESCRIPTION
Replaced deprecated SMI GPIO configuration with up to date.
