### PR TITLE
fix(ch390): memory distribution error of phy_ctl1_reg_t; loopback not work properly (IDFGH-13804)

### DIFF
--- a/ch390/README.md
+++ b/ch390/README.md
@@ -55,3 +55,20 @@ esp_eth_phy_t *phy = esp_eth_phy_new_ch390(&phy_config);
 
 and use the Ethernet driver as you are used to. For more information of how to use ESP-IDF Ethernet driver, visit [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_eth.html).
 
+
+## Version History
+| **Version** | **Date**   | **Description**                                                                                                        |
+|:-----------:|:----------:|--------------------------------------------------------------------------------------------------------------------    |
+| 0.1.0       | 2024-03-06 | Initial Release                                                                                                        |
+| 0.2.0       | 2024-08-29 | Fix start/stop issue: cannot acquire the ip address after several start/stop loops randomly                            |
+| 0.2.1       | 2024-11-25 | Correct some typos in comment; Fix the issue that loopback and auto-negotiation cannot be enabled at the same time     |
+
+## Acknowledgement
+In no particular order:
+- ***kostaond**
+- ***leeebo**
+- igrr
+- bogdankolendovskyy
+- ShunzDai
+
+*Gives **TREMENDOUS** support to the project

--- a/ch390/idf_component.yml
+++ b/ch390/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.2.1"
 description: CH390 Ethernet Driver
 url: https://github.com/espressif/esp-eth-drivers/tree/master/ch390
 dependencies:

--- a/ch390/include/ch390.h
+++ b/ch390/include/ch390.h
@@ -23,7 +23,7 @@ extern "C" {
 #define NCR_WAKEEN      (1<<6) // Enable wakeup function
 #define NCR_FDX         (1<<3) // Duplex mode of the internal PHY
 #define NCR_LBK_MAC     (1<<1) // MAC loop-back
-#define NCR_RST         (1<<0) // Softwate reset
+#define NCR_RST         (1<<0) // Software reset
 
 #define CH390_NSR       0x01   // Network status reg
 #define NSR_SPEED       (1<<7) // Speed of internal PHY
@@ -156,7 +156,7 @@ extern "C" {
 #define CH390_SCCR      0x50   // System clock control reg
 #define CH390_RSCCR     0x51   // Recover system clock control reg
 
-#define CH390_RLENCR            0x52   // Receive data pack lenth control reg
+#define CH390_RLENCR            0x52   // Receive data pack length control reg
 #define RLENCR_RXLEN_EN         0x80   // Enable RX data pack length filter
 #define RLENCR_RXLEN_DEFAULT    0x18   // Default MAX length of RX data(div by 64)
 


### PR DESCRIPTION
As mentioned in #37. 
Besides, add Version History in `README.md` to help users distinguish version differences.