### PR TITLE
fix(enc28j60): added enc28j60 to Component registry upload

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Upload components to the component registry
         uses: espressif/github-actions/upload_components@master
         with:
-          directories: "ksz8863;adin1200;lan867x;ch390;ethernet_init;eth_dummy_phy"
+          directories: "ksz8863;adin1200;lan867x;ch390;enc28j60;ethernet_init;eth_dummy_phy"
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
Follow-up to https://github.com/espressif/esp-eth-drivers/pull/41. ENC28J60 was not listed to be uploaded to Component Registry.