### PR TITLE
feat(eth_init): added Generic 802.3 PHY as supported device

### DIFF
--- a/ethernet_init/Kconfig.projbuild
+++ b/ethernet_init/Kconfig.projbuild
@@ -23,6 +23,15 @@ menu "Ethernet Configuration"
             help
                 Select the Ethernet PHY device to use.
 
+            config ETHERNET_PHY_GENERIC
+                bool "Generic 802.3 PHY"
+                help
+                    Any Ethernet PHY chip compliant with IEEE 802.3 can be used. However, while
+                    basic functionality should always work, some specific features might be limited,
+                    even if the PHY meets IEEE 802.3 standard. A typical example is loopback
+                    functionality, where certain PHYs may require setting a specific speed mode to
+                    operate correctly.
+
             config ETHERNET_PHY_IP101
                 bool "IP101"
                 help

--- a/ethernet_init/README.md
+++ b/ethernet_init/README.md
@@ -4,6 +4,7 @@ This component makes it easier to set up and control Ethernet connections in Esp
 It also allows users to select from various supported Ethernet chips, making development faster.
 
 Supported devices are:
+* Generic 802.3 PHY (any Ethernet PHY chip compliant with IEEE 802.3)
 * IP101
 * RTL8201/SR8201
 * LAN87xx
@@ -15,6 +16,8 @@ Supported devices are:
     * W5500 Module
     * ENC28J60 Module
     * CH390 Module
+
+> ⚠️ **Warning**: When selecting `Generic 802.3 PHY`, basic functionality should always work for PHY compliant with IEEE 802.3. However, some specific features might be limited. A typical example is loopback functionality, where certain PHYs may require setting a specific speed mode to operate correctly.
 
 ## API
 

--- a/ethernet_init/ethernet_init.c
+++ b/ethernet_init/ethernet_init.c
@@ -177,7 +177,9 @@ static esp_eth_handle_t eth_init_internal(eth_device *dev_out)
     phy_config.reset_gpio_num = CONFIG_ETHERNET_PHY_RST_GPIO;
 
     // Create new PHY instance based on board configuration
-#if CONFIG_ETHERNET_PHY_IP101
+#if CONFIG_ETHERNET_PHY_GENERIC
+    dev_out->phy = esp_eth_phy_new_generic(&phy_config);
+#elif CONFIG_ETHERNET_PHY_IP101
     dev_out->phy = esp_eth_phy_new_ip101(&phy_config);
     sprintf(dev_out->dev_info.name, "IP101");
 #elif CONFIG_ETHERNET_PHY_RTL8201

--- a/ethernet_init/idf_component.yml
+++ b/ethernet_init/idf_component.yml
@@ -3,7 +3,7 @@ dependencies:
     rules:
        - if: "target in [esp32, esp32p4]"
   idf:
-    version: '>=5.3'
+    version: '>=5.4'
   espressif/ch390:
     version: '*'
     override_path: '../ch390/'
@@ -14,4 +14,4 @@ examples:
   - path: ../common_examples/
 description: This component initializes Ethernet driver based on Espressif IoT Development Framework Configuration.
 url: https://github.com/espressif/esp-eth-drivers/tree/master/ethernet_init
-version: 0.3.3
+version: 0.4.0


### PR DESCRIPTION
Added Generic 802.3 PHY as supported device in Ethernet Init component.
