### PR TITLE
Fix byte order in TOTMR register

### DIFF
--- a/lan867x/idf_component.yml
+++ b/lan867x/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 targets:
   - esp32
   - esp32p4

--- a/lan867x/include/esp_eth_phy_lan867x.h
+++ b/lan867x/include/esp_eth_phy_lan867x.h
@@ -19,8 +19,8 @@ typedef enum {
     LAN867X_ETH_CMD_G_PLCA_NCNT,                         /*!< Get PLCA node count */
     LAN867X_ETH_CMD_S_PLCA_ID,                           /*!< Set PLCA ID */
     LAN867X_ETH_CMD_G_PLCA_ID,                           /*!< Get PLCA ID */
-    LAN867x_ETH_CMD_S_PLCA_TOT,                          /*!< Set PLCA Transmit Opportunity Timer in incriments of 100ns */
-    LAN867x_ETH_CMD_G_PLCA_TOT,                          /*!< Get PLCA Transmit Opportunity Timer in incriments of 100ns */
+    LAN867X_ETH_CMD_S_PLCA_TOT,                          /*!< Set PLCA Transmit Opportunity Timer in incriments of 100ns */
+    LAN867X_ETH_CMD_G_PLCA_TOT,                          /*!< Get PLCA Transmit Opportunity Timer in incriments of 100ns */
     LAN867X_ETH_CMD_ADD_TX_OPPORTUNITY,                  /*!< Add additional transmit opportunity for chosen node */
     LAN867X_ETH_CMD_RM_TX_OPPORTUNITY,                   /*!< Remove additional transmit opportunity for chosen node */
     LAN867X_ETH_CMD_S_MAX_BURST_COUNT,                   /*!< Set max count of additional packets, set to 0 to disable */

--- a/lan867x/src/esp_eth_phy_lan867x.c
+++ b/lan867x/src/esp_eth_phy_lan867x.c
@@ -47,6 +47,7 @@ typedef union {
         uint32_t reserved1 : 14;    // Reserved
         uint32_t rst : 1;           // PLCA Reset
         uint32_t en : 1;            // PLCA Enable
+        uint16_t padding1;          // Padding
     };
     uint32_t val;
 } lan867x_plca_ctrl0_reg_t;
@@ -54,8 +55,9 @@ typedef union {
 
 typedef union {
     struct {
-        uint8_t id;     // PLCA ID
-        uint8_t ncnt;   // Node count
+        uint8_t id;         // PLCA ID
+        uint8_t ncnt;       // Node count
+        uint16_t padding1;  // Padding
     };
     uint32_t val;
 } lan867x_plca_ctrl1_reg_t;
@@ -63,8 +65,9 @@ typedef union {
 
 typedef union {
     struct {
-        uint8_t reserved1;  // Reserved
         uint8_t totmr;      // Transmit Opportunity Timer
+        uint8_t reserved1;  // Reserved
+        uint16_t padding1;  // Padding
     };
     uint32_t val;
 } lan867x_plca_totmr_reg_t;
@@ -72,8 +75,9 @@ typedef union {
 
 typedef union {
     struct {
-        uint8_t maxbc;  // Maximum burst count
-        uint8_t btmr;   // Burst timer
+        uint8_t btmr;       // Burst timer
+        uint8_t maxbc;      // Maximum burst count
+        uint16_t padding1;  // Padding
     };
     uint32_t val;
 } lan867x_plca_burst_reg_t;
@@ -254,12 +258,12 @@ static esp_err_t lan867x_custom_ioctl(esp_eth_phy_t *phy, int cmd, void *data)
         ESP_GOTO_ON_ERROR(esp_eth_phy_802_3_read_mmd_register(phy_802_3, MISC_REGISTERS_DEVICE, ETH_PHY_PLCA_CTRL1_REG_MMD_ADDR, &plca_ctrl1.val), err, TAG, "read PLCA_CTRL1 failed");
         *((uint8_t *) data) = plca_ctrl1.id;
         break;
-    case LAN867x_ETH_CMD_S_PLCA_TOT:
+    case LAN867X_ETH_CMD_S_PLCA_TOT:
         ESP_GOTO_ON_ERROR(esp_eth_phy_802_3_read_mmd_register(phy_802_3, MISC_REGISTERS_DEVICE, ETH_PHY_PLCA_TOTMR_REG_MMD_ADDR, &plca_totmr.val), err, TAG, "read PLCA_TOTMR failed");
         plca_totmr.totmr = *((uint8_t *) data);
         ESP_GOTO_ON_ERROR(esp_eth_phy_802_3_write_mmd_register(phy_802_3, MISC_REGISTERS_DEVICE, ETH_PHY_PLCA_TOTMR_REG_MMD_ADDR, plca_totmr.val), err, TAG, "write PLCA_TOTMR failed");
         break;
-    case LAN867x_ETH_CMD_G_PLCA_TOT:
+    case LAN867X_ETH_CMD_G_PLCA_TOT:
         ESP_GOTO_ON_ERROR(esp_eth_phy_802_3_read_mmd_register(phy_802_3, MISC_REGISTERS_DEVICE, ETH_PHY_PLCA_TOTMR_REG_MMD_ADDR, &plca_totmr.val), err, TAG, "read PLCA_TOTMR failed");
         *((uint8_t *) data) = plca_totmr.totmr;
         break;


### PR DESCRIPTION
Commit fixes the byte order in the struct that defines TOTMR register and adds padding to prevent possible issues among compilers. Also addresses two typos made in custom_ioctl commands.

Closes https://github.com/espressif/esp-eth-drivers/issues/48


## Description
Fix byte order in `lan867x_plca_totmr_reg_t` and add padding to `lan867x_plca_***_reg_t` structs to prevent possible undefined behaviour. Fix typos in `custom_ioctl` commands
```diff
--- LAN867x_ETH_CMD_S_PLCA_TOT
+++ LAN867X_ETH_CMD_S_PLCA_TOT
```
and
```diff
--- LAN867x_ETH_CMD_G_PLCA_TOT
+++ LAN867X_ETH_CMD_G_PLCA_TOT
```
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
