### PR TITLE
feat(ch390): Add support of CH390D; Remove beta symbol (IDFGH-14649)

### DIFF
--- a/ch390/README.md
+++ b/ch390/README.md
@@ -1,4 +1,4 @@
-# WCH CH390H Ethernet Driver (beta)
+# WCH CH390H/D Ethernet Driver
 
 ## Overview
 
@@ -62,6 +62,7 @@ and use the Ethernet driver as you are used to. For more information of how to u
 | 0.1.0       | 2024-03-06 | Initial Release                                                                                                        |
 | 0.2.0       | 2024-08-29 | Fix start/stop issue: cannot acquire the ip address after several start/stop loops randomly                            |
 | 0.2.1       | 2024-11-25 | Correct some typos in comment; Fix the issue that loopback and auto-negotiation cannot be enabled at the same time     |
+| 0.2.2       | 2025-2-14  | Add support of CH390D; Remove beta symbol                                                                              |
 
 ## Acknowledgement
 In no particular order:

--- a/ch390/idf_component.yml
+++ b/ch390/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.1"
+version: "0.2.2"
 description: CH390 Ethernet Driver
 url: https://github.com/espressif/esp-eth-drivers/tree/master/ch390
 dependencies:

--- a/ch390/src/esp_eth_mac_ch390.c
+++ b/ch390/src/esp_eth_mac_ch390.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * SPDX-FileContributor: 2024 Sergey Kharenko
+ * SPDX-FileContributor: 2024-2025 Sergey Kharenko
  * SPDX-FileContributor: 2024 Espressif Systems (Shanghai) CO LTD
  */
 
@@ -310,7 +310,7 @@ static esp_err_t ch390_reset(emac_ch390_t *emac)
     }
     ESP_GOTO_ON_FALSE(to < emac->sw_reset_timeout_ms / 10, ESP_ERR_TIMEOUT, err, TAG, "reset timeout");
 
-    /* For CH390H, phy should be power on after software reset !*/
+    /* For CH390H/D, phy should be power on after software reset !*/
     ESP_GOTO_ON_ERROR(ch390_io_register_write(emac, CH390_GPR, 0x00), err, TAG, "write GPR failed");
     /* mac and phy register won't be accesable within at least 1ms */
     vTaskDelay(pdMS_TO_TICKS(10));


### PR DESCRIPTION
WCH release new variants in of CH390 2024 Q4: CH390D and CH390F. We just focus on CH390D which has SPI Interface.
In brief, CH390D has the advantages below:
1. **Smaller package.** Package size of CH390D is as small as 3mm x 3mm , compared to 5mm x 5mm of CH390H. 
2. **Simpler peripheral circuits.**  CH390D has much less pins(QFN20 compared to QFN32).
3. **WCH Official Recommendation.**
4. **Hardware Bug Fix.** According to my test, issue in #23 as @kostaond proposed has been solved by WCH
![CH390D_Test](https://github.com/user-attachments/assets/f72d36bb-5014-4099-b5dc-ce43f0ec1cff)

At driver level, there is nothing that needs to be specially modified, CH390H and CH390D could share the same driver according to my test. Therefore, only comments are modified in this PR. At cost level, CH390D is less than 1 CNY more expensive than CH390H. Considering its late release, I believe it would be cheaper after large-scale shipments. 
