### PR TITLE
fix(28j60): Use proper component in older IDF versions

### DIFF
--- a/enc28j60/CMakeLists.txt
+++ b/enc28j60/CMakeLists.txt
@@ -1,4 +1,12 @@
+set(priv_requires esp_eth)
+
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER "5.3")
+    list(APPEND priv_requires esp_driver_gpio esp_driver_spi)
+else()
+    list(APPEND priv_requires driver)
+endif()
+
 idf_component_register(SRCS "src/esp_eth_mac_enc28j60.c"
                             "src/esp_eth_phy_enc28j60.c"
-                       PRIV_REQUIRES esp_driver_gpio esp_driver_spi esp_eth
+                       PRIV_REQUIRES ${priv_requires}
                        INCLUDE_DIRS "include")


### PR DESCRIPTION
In ESP-IDF <v5.3 there are no `esp_driver_XXX` components, and general component `driver` must be included instead.
The only component affected so far is ENC28J60, this PR adds a simple conditional check which includes the correct component depending on the version used.