### PR TITLE
feat(dm9051): Add custom ioctl for EEE (802.3az) on DM9051 (IDFGH-17057)

### DIFF
--- a/dm9051/include/esp_eth_mac_dm9051.h
+++ b/dm9051/include/esp_eth_mac_dm9051.h
@@ -51,6 +51,14 @@ typedef struct {
 */
 esp_eth_mac_t *esp_eth_mac_new_dm9051(const eth_dm9051_config_t *dm9051_config, const eth_mac_config_t *mac_config);
 
+/**
+ * @brief List of SPI EMAC specific commands for ioctl API
+ *
+ */
+typedef enum {
+    ETH_MAC_SPI_CMD_S_EEE = ETH_CMD_CUSTOM_MAC_CMDS_OFFSET, /*!< Enable or disable Energy Efficient Ethernet */
+} eth_mac_spi_io_cmd_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/dm9051/src/dm9051.h
+++ b/dm9051/src/dm9051.h
@@ -131,6 +131,8 @@ extern "C" {
 #define TCSCR_TCPCSE (1 << 1) // TCP CheckSum Generation
 #define TCSCR_IPCSE (1 << 0)  // IPv4 CheckSum Generation
 
+#define EEE_EN (1 << 7)  // EEE Enable
+
 #define MPTRCR_RST_TX (1 << 1) // Reset TX Memory Pointer
 #define MPTRCR_RST_RX (1 << 0) // Reset RX Memory Pointer
 

--- a/dm9051/src/esp_eth_mac_dm9051.c
+++ b/dm9051/src/esp_eth_mac_dm9051.c
@@ -700,6 +700,30 @@ static esp_err_t emac_dm9051_set_peer_pause_ability(esp_eth_mac_t *mac, uint32_t
     return ESP_OK;
 }
 
+esp_err_t emac_dm9051_custom_ioctl(esp_eth_mac_t *mac, int cmd, void *data)
+{
+    emac_dm9051_t *emac = __containerof(mac, emac_dm9051_t, parent);
+
+    switch (cmd) {
+    case ETH_MAC_SPI_CMD_S_EEE: {
+        ESP_RETURN_ON_FALSE(data, ESP_ERR_INVALID_ARG, TAG, "EEE set configuration invalid argument, cant' be NULL");
+        bool enable = *((bool *)data);
+        uint8_t eee_out = 0;
+        ESP_RETURN_ON_ERROR(dm9051_register_read(emac, DM9051_EEE_OUT, &eee_out), TAG, "failed to read DM9051_EEE_OUT");
+        if (enable) {
+            eee_out |= EEE_EN;
+        } else {
+            eee_out &= ~EEE_EN;
+        }
+        ESP_RETURN_ON_ERROR(dm9051_register_write(emac, DM9051_EEE_OUT, eee_out), TAG, "failed to write DM9051_EEE_OUT");
+        break;
+    }
+    default:
+        ESP_RETURN_ON_ERROR(ESP_ERR_INVALID_ARG, TAG, "unknown io command: %i", cmd);
+    }
+    return ESP_OK;
+}
+
 static esp_err_t emac_dm9051_transmit(esp_eth_mac_t *mac, uint8_t *buf, uint32_t length)
 {
     esp_err_t ret = ESP_OK;
@@ -982,6 +1006,7 @@ esp_eth_mac_t *esp_eth_mac_new_dm9051(const eth_dm9051_config_t *dm9051_config, 
     emac->parent.receive = emac_dm9051_receive;
     emac->parent.add_mac_filter = emac_dm9051_add_mac_filter;
     emac->parent.rm_mac_filter = emac_dm9051_rm_mac_filter;
+    emac->parent.custom_ioctl = emac_dm9051_custom_ioctl;
 
     if (dm9051_config->custom_spi_driver.init != NULL && dm9051_config->custom_spi_driver.deinit != NULL
             && dm9051_config->custom_spi_driver.read != NULL && dm9051_config->custom_spi_driver.write != NULL) {


### PR DESCRIPTION

## Description

Allow enabling EEE on DM9051 by ioctl. The resulting power savings are around 200 mW on a 100baseT link.

## Related

This is the same code as in the now obsolete https://github.com/espressif/esp-idf/pull/16138 based on previous discussion there

## Testing

Briefly run tested on a PoE powered ESP32C3 using a DM9051, using the PoE switch to measure total power consumption for the module.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables runtime control of Energy Efficient Ethernet on DM9051 through the MAC ioctl API.
> 
> - Implements `custom_ioctl` in `esp_eth_mac_dm9051.c` to handle `ETH_MAC_SPI_CMD_S_EEE`, toggling the `EEE_EN` bit in `DM9051_EEE_OUT`
> - Exposes new ioctl command enum `ETH_MAC_SPI_CMD_S_EEE` in `esp_eth_mac_dm9051.h`
> - Defines `EEE_EN` flag in `dm9051.h` and wires `parent.custom_ioctl` during MAC init
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 562d6409148363e6b760def6741b51e1177f9010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->