### PR TITLE
fix(lan86xx): Fix PHY command offset reference (IDFGH-17512)

### DIFF
--- a/lan86xx_common/include/esp_eth_phy_lan86xx.h
+++ b/lan86xx_common/include/esp_eth_phy_lan86xx.h
@@ -13,21 +13,21 @@ extern "C" {
 #endif
 
 typedef enum {
-    LAN86XX_ETH_CMD_S_EN_PLCA = ETH_CMD_CUSTOM_PHY_CMDS, /*!< Enable or disable PLCA */
-    LAN86XX_ETH_CMD_G_EN_PLCA,                           /*!< Get status if PLCA is disabled or enabled*/
-    LAN86XX_ETH_CMD_S_PLCA_NCNT,                         /*!< Set PLCA node count */
-    LAN86XX_ETH_CMD_G_PLCA_NCNT,                         /*!< Get PLCA node count */
-    LAN86XX_ETH_CMD_S_PLCA_ID,                           /*!< Set PLCA ID */
-    LAN86XX_ETH_CMD_G_PLCA_ID,                           /*!< Get PLCA ID */
-    LAN86XX_ETH_CMD_S_PLCA_TOT,                          /*!< Set PLCA Transmit Opportunity Timer in incriments of 100ns */
-    LAN86XX_ETH_CMD_G_PLCA_TOT,                          /*!< Get PLCA Transmit Opportunity Timer in incriments of 100ns */
-    LAN86XX_ETH_CMD_ADD_TX_OPPORTUNITY,                  /*!< Add additional transmit opportunity for chosen node */
-    LAN86XX_ETH_CMD_RM_TX_OPPORTUNITY,                   /*!< Remove additional transmit opportunity for chosen node */
-    LAN86XX_ETH_CMD_S_MAX_BURST_COUNT,                   /*!< Set max count of additional packets, set to 0 to disable */
-    LAN86XX_ETH_CMD_G_MAX_BURST_COUNT,                   /*!< Get max count of additional packets, set to 0 to disable */
-    LAN86XX_ETH_CMD_S_BURST_TIMER,                       /*!< Set time after transmission during which node is allowed to transmit more packets in incriments of 100ns */
-    LAN86XX_ETH_CMD_G_BURST_TIMER,                       /*!< Get time after transmission during which node is allowed to transmit more packets in incriments of 100ns */
-    LAN86XX_ETH_CMD_PLCA_RST                             /*!< Reset PLCA*/
+    LAN86XX_ETH_CMD_S_EN_PLCA = ETH_CMD_CUSTOM_PHY_CMDS_OFFSET, /*!< Enable or disable PLCA */
+    LAN86XX_ETH_CMD_G_EN_PLCA,                                  /*!< Get status if PLCA is disabled or enabled*/
+    LAN86XX_ETH_CMD_S_PLCA_NCNT,                                /*!< Set PLCA node count */
+    LAN86XX_ETH_CMD_G_PLCA_NCNT,                                /*!< Get PLCA node count */
+    LAN86XX_ETH_CMD_S_PLCA_ID,                                  /*!< Set PLCA ID */
+    LAN86XX_ETH_CMD_G_PLCA_ID,                                  /*!< Get PLCA ID */
+    LAN86XX_ETH_CMD_S_PLCA_TOT,                                 /*!< Set PLCA Transmit Opportunity Timer in incriments of 100ns */
+    LAN86XX_ETH_CMD_G_PLCA_TOT,                                 /*!< Get PLCA Transmit Opportunity Timer in incriments of 100ns */
+    LAN86XX_ETH_CMD_ADD_TX_OPPORTUNITY,                         /*!< Add additional transmit opportunity for chosen node */
+    LAN86XX_ETH_CMD_RM_TX_OPPORTUNITY,                          /*!< Remove additional transmit opportunity for chosen node */
+    LAN86XX_ETH_CMD_S_MAX_BURST_COUNT,                          /*!< Set max count of additional packets, set to 0 to disable */
+    LAN86XX_ETH_CMD_G_MAX_BURST_COUNT,                          /*!< Get max count of additional packets, set to 0 to disable */
+    LAN86XX_ETH_CMD_S_BURST_TIMER,                              /*!< Set time after transmission during which node is allowed to transmit more packets in incriments of 100ns */
+    LAN86XX_ETH_CMD_G_BURST_TIMER,                              /*!< Get time after transmission during which node is allowed to transmit more packets in incriments of 100ns */
+    LAN86XX_ETH_CMD_PLCA_RST                                    /*!< Reset PLCA*/
 } phy_lan86xx_custom_io_cmd_t;
 
 /**


### PR DESCRIPTION
## Description

`ETH_CMD_CUSTOM_PHY_CMDS` is not available in `esp_eth_phy_lan86xx.h` as it is defined in `esp_eth_driver.h`, so changed to the reference `ETH_CMD_CUSTOM_PHY_CMDS_OFFSET` available from the already-included `esp_eth_phy.h`.

All examples currently use the `ethernet_init` component, which includes `esp_eth_driver.h` before any PHY-specific headers, which might be why this hasn't been picked up previously. For our project, we don't want the overhead of the whole `ethernet_init` component, so only include `esp_eth_phy_lan865x.h`, hence discovering this issue.

## Related

No related issues/PRs found.

## Testing

This change was tested by by using it to build our project, which was failing before, and checking it succeeded this time. Then a verification that the driver still works as expected, on a device with an LAN8651 chip, using the `tcp_client` and `tcp_server` examples.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single constant reference change to fix header compilation when `esp_eth_driver.h` isn’t included, with no behavioral logic changes.
> 
> **Overview**
> Fixes LAN86xx PHY custom IO command numbering by switching the enum base from `ETH_CMD_CUSTOM_PHY_CMDS` to `ETH_CMD_CUSTOM_PHY_CMDS_OFFSET` in `esp_eth_phy_lan86xx.h`, removing an implicit dependency on `esp_eth_driver.h` and allowing projects to include only PHY headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f2927baa7a6299176f46b4d709ef449cd9a248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->