### PR TITLE
chore: remove redundant quotes in CMakeLists.txt (IDFGH-17724)

### DIFF
--- a/ip101/CMakeLists.txt
+++ b/ip101/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "src/esp_eth_phy_ip101.c"
                        INCLUDE_DIRS "include"
-                       PRIV_REQUIRES "log esp_eth")
+                       PRIV_REQUIRES log esp_eth)


### PR DESCRIPTION
## Description

without this Change it says: "Component not Found <<log esp_eth>>

## Related

https://github.com/espressif/esp-idf/issues/17833

## Testing

apply this Change: can compile again. 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
