### PR TITLE
RXCR1_RXUDPFCC breaks IPv6 UDP (IDFGH-17917)

### DIFF
--- a/ksz8851snl/src/esp_eth_mac_ksz8851snl.c
+++ b/ksz8851snl/src/esp_eth_mac_ksz8851snl.c
@@ -311,7 +311,8 @@ static esp_err_t init_set_defaults(emac_ksz8851snl_t *emac)
     ESP_GOTO_ON_ERROR(ksz8851_set_bits(emac, KSZ8851_RXDTTR, RXDTTR_INIT_VALUE), err, TAG, "RXDTTR write failed");
     ESP_GOTO_ON_ERROR(ksz8851_set_bits(emac, KSZ8851_RXDBCTR, RXDBCTR_INIT_VALUE), err, TAG, "RXDBCTR write failed");
     ESP_GOTO_ON_ERROR(ksz8851_set_bits(emac, KSZ8851_RXCR1,
-                                       RXCR1_RXUDPFCC | RXCR1_RXTCPFCC | RXCR1_RXIPFCC | RXCR1_RXPAFMA | RXCR1_RXFCE | RXCR1_RXUE | RXCR1_RXME | RXCR1_RXAE | RXCR1_RXBE), err, TAG, "RXCR1 write failed");
+                                       // RXCR1_RXUDPFCC | // Do not set as filters valid IPv6 UDP packets 
+                                        RXCR1_RXTCPFCC | RXCR1_RXIPFCC | RXCR1_RXPAFMA | RXCR1_RXFCE | RXCR1_RXUE | RXCR1_RXME | RXCR1_RXAE | RXCR1_RXBE), err, TAG, "RXCR1 write failed");
     ESP_GOTO_ON_ERROR(ksz8851_set_bits(emac, KSZ8851_RXCR2,
                                        (4 << RXCR2_SRDBL_SHIFT) | RXCR2_IUFFP | RXCR2_RXIUFCEZ | RXCR2_UDPLFE | RXCR2_RXICMPFCC), err, TAG, "RXCR2 write failed");
     ESP_GOTO_ON_ERROR(ksz8851_set_bits(emac, KSZ8851_RXQCR, RXQCR_RXFCTE | RXQCR_ADRFE), err, TAG, "RXQCR write failed");


### PR DESCRIPTION
## Description

It seems valid IPv6 UDP packets are filtered when this issue set.

As this seems to be a hardware bug, it is not sensible to use this feature.

I left a comment in the commented out flag to make it clear why omitted.

## Testing

I could not receive any valid IPv6 UDP packets - having made this change I now can.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line register default change in the Ethernet MAC driver; improves IPv6 UDP receive with no API changes.
> 
> **Overview**
> During KSZ8851SNL MAC default init, **`RXCR1_RXUDPFCC`** is no longer set in **`RXCR1`**, so the chip does not run receive UDP checksum verification that was dropping **valid IPv6 UDP** traffic.
> 
> The bit is left commented with a short note attributing the behavior to a hardware limitation. **TCP/IP receive checksum checks and the rest of the `RXCR1` mask are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e08370d052df0a49c6a7a590b435aa432939d7ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->